### PR TITLE
Avoid note about non-standard file in root

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^charts/.*$
 ^colors/.*$
 ^example_script\.R$
+^README\.Rmd$


### PR DESCRIPTION
Fix R CMD note:

```
❯ checking top-level files ... NOTE
  Non-standard file/directory found at top level:
    ‘README.Rmd’
```