### PR TITLE
Suggest problematic 'ggsignif' package from GitHub

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Imports:
 Suggests: 
     r2dii.analysis,
     r2dii.match,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    ggsignif
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,9 +32,11 @@ Suggests:
     r2dii.analysis,
     r2dii.match,
     testthat (>= 3.0.0),
-    ggsignif
+    ggsignif (>= 0.6.1)
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
+Remotes:  
+    const-ae/ggsignif


### PR DESCRIPTION
ggsignif is a dependency of ggpubr. Usually we do not need to install a dependency of a dependency but here I do it as a hack.

I don't know why, but GitHub actions is failing to install ggsignif from CRAN. To get around this problem, this PR installs ggsignif from GitHub instead of CRAN. This won't be acceptable when you submit to CRAN, but by then I hope to have pruned as many dependencies as possible, maybe including ggpubr -- which seems quite heavy. 