### PR TITLE
Store a more robust snapshot

### DIFF
--- a/tests/testthat/_snaps/get_example_data.md
+++ b/tests/testthat/_snaps/get_example_data.md
@@ -1,20 +1,20 @@
 # outputs the expected snapshot
 
     Code
-      get_example_data()
+      some_example_data
     Output
-      # A tibble: 1,170 x 8
-         sector technology  year region scenario_source metric production
-         <chr>  <chr>      <int> <chr>  <chr>           <chr>       <dbl>
-       1 autom~ electric    2020 global demo_2020       proje~    145942.
-       2 autom~ electric    2020 global demo_2020       corpo~   8134869.
-       3 autom~ electric    2020 global demo_2020       targe~    145942.
-       4 autom~ electric    2020 global demo_2020       targe~    145942.
-       5 autom~ electric    2020 global demo_2020       targe~    145942.
-       6 autom~ electric    2021 global demo_2020       proje~    148212.
-       7 autom~ electric    2021 global demo_2020       corpo~   8183411.
-       8 autom~ electric    2021 global demo_2020       targe~    148361.
-       9 autom~ electric    2021 global demo_2020       targe~    160625.
-      10 autom~ electric    2021 global demo_2020       targe~    149016.
-      # ... with 1,160 more rows, and 1 more variable: technology_share <dbl>
+            sector technology year region scenario_source            metric
+      1 automotive   electric 2020 global       demo_2020         projected
+      2 automotive   electric 2020 global       demo_2020 corporate_economy
+      3 automotive   electric 2020 global       demo_2020        target_cps
+      4 automotive   electric 2020 global       demo_2020        target_sds
+      5 automotive   electric 2020 global       demo_2020        target_sps
+      6 automotive   electric 2021 global       demo_2020         projected
+        production technology_share
+      1   145942.3       0.18274621
+      2  8134868.7       0.05662567
+      3   145942.3       0.06488835
+      4   145942.3       0.06488835
+      5   145942.3       0.06488835
+      6   148211.7       0.18265671
 

--- a/tests/testthat/test-get_example_data.R
+++ b/tests/testthat/test-get_example_data.R
@@ -22,7 +22,8 @@ test_that("has the expected type of columns", {
 })
 
 test_that("outputs the expected snapshot", {
-  expect_snapshot(get_example_data())
+  some_example_data <- head(as.data.frame(get_example_data()))
+  expect_snapshot(some_example_data)
 })
 
 test_that("outputs like r2dii.analysis::target_market_share()", {


### PR DESCRIPTION
This PR fixes a problem I saw on CI. A snapshot was failing because the print method of tibble was slightly different locally versus CI. Tibble likely includes a way to deal with this more elegantly, but instead here I use the simpler approach of converting the tibble to a vanilla dataframe -- which prints the same everywhere.

(As of this writing I see some checks failing on macos and windows but for a reason that is irrelevant to this PR. That problem is fixed at #57.)